### PR TITLE
Add CRUD endpoints for activities API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [0.2.0](https://github.com/mateusmacedo/febrafar-back-php/compare/v0.1.0...v0.2.0) (2024-06-10)
+
+### Features
+
+* :sparkles: add activity management endpoints ([287f62](https://github.com/mateusmacedo/febrafar-back-php/commit/287f62cc492df02bf1a21187a847622210599bb7))
+* :sparkles: add activity model and migrations ([e460a5](https://github.com/mateusmacedo/febrafar-back-php/commit/e460a5ac3ee01db2c369d67ca95840b7a6e272ab))
+
+### Tests
+
+* :test_tube: add feature tests for activities api ([fecc4e](https://github.com/mateusmacedo/febrafar-back-php/commit/fecc4e109c1eb8a46f54a392eab66d9354b2d842))
+
+
+---
+
 ## [0.1.0](https://github.com/mateusmacedo/febrafar-back-php/compare/v0.0.0...v0.1.0) (2024-06-10)
 
 ### Features

--- a/app/Http/Controllers/ActivityController.php
+++ b/app/Http/Controllers/ActivityController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Activity;
+use Illuminate\Http\Request;
+
+class ActivityController extends Controller
+{
+    public function index()
+    {
+        $activities = Activity::all();
+        return response()->json($activities);
+    }
+
+    public function store(Request $request)
+    {
+        $validatedData = $request->validate([
+            'title' => 'required|string|max:255',
+            'type' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'user_id' => 'required|exists:users,id',
+            'start_date' => 'required|date',
+            'due_date' => 'required|date|after_or_equal:start_date',
+            'completion_date' => 'nullable|date|after_or_equal:start_date',
+            'status' => 'required|in:open,completed',
+        ]);
+
+        $activity = Activity::create($validatedData);
+        return response()->json($activity, 201);
+    }
+
+    public function show(Activity $activity)
+    {
+        return response()->json($activity);
+    }
+
+    public function update(Request $request, Activity $activity)
+    {
+        $validatedData = $request->validate([
+            'title' => 'sometimes|required|string|max:255',
+            'type' => 'sometimes|required|string|max:255',
+            'description' => 'nullable|string',
+            'user_id' => 'sometimes|required|exists:users,id',
+            'start_date' => 'sometimes|required|date',
+            'due_date' => 'sometimes|required|date|after_or_equal:start_date',
+            'completion_date' => 'nullable|date|after_or_equal:start_date',
+            'status' => 'required|in:open,completed',
+        ]);
+
+        $activity->update($validatedData);
+        return response()->json($activity);
+    }
+
+    public function destroy(Activity $activity)
+    {
+        $activity->delete();
+        return response()->json(null, 204);
+    }
+}

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Activity extends Model
+{
+    use HasFactory;
+    protected $fillable = [
+        'title',
+        'type',
+        'description',
+        'user_id',
+        'start_date',
+        'due_date',
+        'completion_date',
+        'status',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -108,5 +108,5 @@
         "unit-test:type": "vendor/bin/pest --type-coverage"
     },
     "type": "project",
-    "version": "0.1.0"
+    "version": "0.2.0"
 }

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Activity;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ActivityFactory extends Factory
+{
+    protected $model = Activity::class;
+
+    public function definition()
+    {
+        return [
+            'title' => $this->faker->sentence,
+            'type' => $this->faker->word,
+            'description' => $this->faker->paragraph,
+            'user_id' => User::factory(),
+            'start_date' => $this->faker->dateTimeBetween('-1 month', '+1 month')->format('Y-m-d H:i:s'),
+            'due_date' => $this->faker->dateTimeBetween('+1 month', '+2 months')->format('Y-m-d H:i:s'),
+            'completion_date' => null,
+            'status' => 'open',
+        ];
+    }
+}

--- a/database/migrations/2024_06_08_041811_create_activities_table.php
+++ b/database/migrations/2024_06_08_041811_create_activities_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('activities', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('type');
+            $table->text('description')->nullable();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->dateTime('start_date');
+            $table->dateTime('due_date');
+            $table->dateTime('completion_date')->nullable();
+            $table->enum('status', ['open', 'completed'])->default('open');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('activities');
+    }
+};

--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
         "laravel-vite-plugin": "^1.0.0",
         "vite": "^5.0.0"
     },
-    "version": "0.1.0"
+    "version": "0.2.0"
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Http\Controllers\ActivityController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+
 
 /*
 |--------------------------------------------------------------------------
@@ -17,3 +19,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::apiResource('activities', ActivityController::class);

--- a/tests/Feature/ActivityControllerTest.php
+++ b/tests/Feature/ActivityControllerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Activity;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ActivityControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_create_activity()
+    {
+        $user = User::factory()->create();
+
+        $data = [
+            'title' => 'Test Activity',
+            'type' => 'Custom Type',
+            'description' => 'Description for test activity',
+            'user_id' => $user->id,
+            'start_date' => Carbon::now()->format('Y-m-d H:i:s'),
+            'due_date' => Carbon::now()->addDay()->format('Y-m-d H:i:s'),
+            'status' => 'open',
+        ];
+
+        $response = $this->postJson('/api/activities', $data);
+
+        $response->assertStatus(201)
+                 ->assertJsonFragment(['title' => 'Test Activity']);
+    }
+
+    public function test_can_update_activity()
+    {
+        $activity = Activity::factory()->create();
+        $data = [
+            'title' => 'Updated Activity',
+            'status' => 'open'
+        ];
+
+        $response = $this->putJson("/api/activities/{$activity->id}", $data);
+
+        $response->assertStatus(200)
+                 ->assertJsonFragment(['title' => 'Updated Activity']);
+    }
+
+    public function test_can_delete_activity()
+    {
+        $activity = Activity::factory()->create();
+
+        $response = $this->deleteJson("/api/activities/{$activity->id}");
+
+        $response->assertStatus(204);
+    }
+
+    public function test_can_list_activities()
+    {
+        Activity::factory()->count(5)->create();
+
+        $response = $this->getJson('/api/activities');
+
+        $response->assertStatus(200)
+                 ->assertJsonStructure([
+                     '*' => ['id', 'title', 'type', 'description', 'user_id', 'start_date', 'due_date', 'completion_date', 'status', 'created_at', 'updated_at']
+                 ]);
+    }
+
+    public function test_can_show_activity()
+    {
+        $activity = Activity::factory()->create();
+
+        $response = $this->getJson("/api/activities/{$activity->id}");
+
+        $response->assertStatus(200)
+                 ->assertJsonFragment(['title' => $activity->title]);
+    }
+}


### PR DESCRIPTION
This pull request adds CRUD endpoints for activities to handle basic operations (create, read, update, delete) via API. It also includes feature tests for the activities API. These changes enhance the application's capability to manage activity-related data, ensuring better organizational functionality and user interaction.